### PR TITLE
Add description field to images/image_id/vuln/all api

### DIFF
--- a/anchore_engine/services/apiext/api/controllers/utils.py
+++ b/anchore_engine/services/apiext/api/controllers/utils.py
@@ -531,6 +531,7 @@ def make_response_vulnerability_report(vulnerability_type, vulnerability_report)
         vuln_dict["feed"] = result.vulnerability.feed
         vuln_dict["feed_group"] = result.vulnerability.feed_group
         vuln_dict["will_not_fix"] = result.fix.will_not_fix
+        vuln_dict["description"] = result.vulnerability.description
         # backwards compatibility hack
         if result.vulnerability.feed_group and "nvd" in result.vulnerability.feed_group:
             vuln_dict["nvd_data"] = get_nvd_data_from_vulnerability(

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -456,12 +456,15 @@ class LegacyProvider(VulnerabilitiesProvider):
                             )
 
                 fixed_in = vuln.fixed_in(fixed_in=fixed_artifact)
+                descriptions = [
+                    record.description for record in nvd_records if record.description
+                ]
 
                 results.append(
                     VulnerabilityMatch(
                         vulnerability=VulnerabilityModel(
                             vulnerability_id=vuln.vulnerability_id,
-                            description=None,
+                            description=descriptions[0] if descriptions else "",
                             severity=vuln.vulnerability.severity,
                             link=vuln.vulnerability.link,
                             feed="vulnerabilities",
@@ -525,7 +528,7 @@ class LegacyProvider(VulnerabilitiesProvider):
                         VulnerabilityMatch(
                             vulnerability=VulnerabilityModel(
                                 vulnerability_id=vulnerability_cpe.parent.normalized_id,
-                                description=None,
+                                description=vulnerability_cpe.parent.description,
                                 severity=vulnerability_cpe.parent.severity,
                                 link=link,
                                 feed=vulnerability_cpe.feed_name,


### PR DESCRIPTION
Support the description field in the images/{image_digest}/vuln/all api.
The change touches the policy-engine and the api services