### PR TITLE
Spring4shell hotfix

### DIFF
--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -2153,16 +2153,29 @@ class ImagePackage(Base):
 
         pkgkey = pkgversion = None
         likematch = None
+        pkg_name_like = None
         if self.pkg_type in ["java", "maven"]:
             # search for maven hits
             if self.metadata_json:
                 pombuf = self.metadata_json.get("pom.properties", "")
                 if pombuf:
                     pomprops = self.get_pom_properties()
-                    pkgkey = "{}:{}".format(
-                        pomprops.get("groupId"), pomprops.get("artifactId")
-                    )
-                    pkgversion = pomprops.get("version", None)
+                    # TODO - remove this spring4shell hotfix
+                    #  normalization in case of empty pomprops
+                    # {"pom.properties": "groupId=None, artifactId=None, version=None"}
+                    if pomprops.get("groupId") and pomprops.get("artifactId"):
+                        pkgkey = "{}:{}".format(
+                            pomprops.get("groupId"), pomprops.get("artifactId")
+                        )
+                    elif "spring" in self.name:
+                        pkg_name_like = "%{}%".format(self.name)
+                    else:
+                        pkgkey = self.name
+                    if pomprops.get("version", None):
+                        pkgversion = pomprops.get("version", None)
+                    else:
+                        pkgversion = self.version
+
                     likematch = "%java%"
                     do_langscan = True
 
@@ -2212,12 +2225,20 @@ class ImagePackage(Base):
                     "performing LANGPACK vuln scan {} - {}".format(pkgkey, pkgversion)
                 )
                 if pkgkey and pkgversion and likematch:
-                    candidates = (
-                        db.query(FixedArtifact)
-                        .filter(FixedArtifact.name == pkgkey)
-                        .filter(FixedArtifact.version_format == "semver")
-                        .filter(FixedArtifact.namespace_name.like(likematch))
-                    )
+                    if pkg_name_like:
+                        candidates = (
+                            db.query(FixedArtifact)
+                            .filter(FixedArtifact.name.like(pkg_name_like))
+                            .filter(FixedArtifact.version_format == "semver")
+                            .filter(FixedArtifact.namespace_name.like(likematch))
+                        )
+                    else:
+                        candidates = (
+                            db.query(FixedArtifact)
+                            .filter(FixedArtifact.name == pkgkey)
+                            .filter(FixedArtifact.version_format == "semver")
+                            .filter(FixedArtifact.namespace_name.like(likematch))
+                        )
                     for candidate in candidates:
                         if (
                             candidate.vulnerability_id

--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -2126,7 +2126,8 @@ class ImagePackage(Base):
                 kv = line.split("=")
                 key = kv[0].strip()
                 value = "=".join(kv[1:]).strip()
-                props[key] = value
+                if value != "None":
+                    props[key] = value
         return props
 
     def find_vulnerabilities(self):
@@ -2224,8 +2225,13 @@ class ImagePackage(Base):
                 log.debug(
                     "performing LANGPACK vuln scan {} - {}".format(pkgkey, pkgversion)
                 )
-                if pkgkey and pkgversion and likematch:
+                if (pkgkey or pkg_name_like) and pkgversion and likematch:
                     if pkg_name_like:
+                        log.debug(
+                            "performing LANGPACK like vuln scan {} - {}".format(
+                                pkg_name_like, pkgversion
+                            )
+                        )
                         candidates = (
                             db.query(FixedArtifact)
                             .filter(FixedArtifact.name.like(pkg_name_like))


### PR DESCRIPTION
**What this PR does / why we need it**:
Detect vulnerabilities in Java packages where Syft did not find POM properties.


